### PR TITLE
Fixed grammatical error on the fragments page

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 				<h1>Fragments Navigation</h1>
 				<p>The built in fragments navigation allows to advance step by step inside a page.<br>
 					Press down to try.</p>
-				<p class="ft-fragment">You can discover single elements <span class="ft-fragment">or even a single part of an element, <span class="ft-fragment">one <span class="ft-fragment">at <span class="ft-fragment">time.</span></span></span></span></p>
+				<p class="ft-fragment">You can discover single elements <span class="ft-fragment">or even a single part of an element, <span class="ft-fragment">one <span class="ft-fragment">at <span class="ft-fragment">a <span class="ft-fragment">time.</span></span></span></span></span></p>
 				<p class="ft-fragment">Fragments navigation is deeply customizable with some configuration options<br>
 					You can learn how in the <a href="https://github.com/marcolago/flowtime.js" target="_blank">documentation</a>.</p>
 			</div>


### PR DESCRIPTION
One at time => one at a time.
