### PR TITLE
Left align content in list items

### DIFF
--- a/css/themes/default.css
+++ b/css/themes/default.css
@@ -360,6 +360,10 @@ body {
 	vertical-align: middle;
 }
 
+.flowtime .stack-center .stacked-center li {
+	text-align: left;
+}
+
 /* media queries */
 
 @media screen and (min-height: 41em) and (min-width: 80em)


### PR DESCRIPTION
Putting a list inside a centered context makes items content centered while I would expected they remain aligned on their bullets. For example:

``` html
<div class="stack-center">
  <div class="stacked-center">
    <h1>Supported operations</h1>
    <ul>
      <li>Both by myself and another</li>
      <li>Creating an item</li>
      <li>Modifying an existing item</li>
      <li>Deleting an item</li>
    </ul>
  </div>
</div>
```

Currently it displays:

![centered](https://f.cloud.github.com/assets/449671/1949388/b7c43042-8100-11e3-8532-60825c9fa782.png)

Restoring alignment gives:

![left](https://f.cloud.github.com/assets/449671/1949389/c1ff0c08-8100-11e3-942c-dbf98d1b2584.png)

Not sure if restoring alignment on all items would not be better.
